### PR TITLE
Update sharamov.R

### DIFF
--- a/R/sharamov.R
+++ b/R/sharamov.R
@@ -19,7 +19,7 @@ addBingTiles <- function(
   map,
   apikey = Sys.getenv("BING_MAPS_API_KEY"),
   imagerySet = c("Aerial", "AerialWithLabels",
-                 "CanvasDark", "CanvasLight", "CanvasGray",
+                 "CanvasDark", "CanvasLight", "CanvasGray","AerialWithLabelsOnDemand","BirdseyeV2WithLabels",
                  "Road"),
   layerId = NULL,
   group = NULL,


### PR DESCRIPTION
AerialWithLabels has been deprecated and new changes won't be made to this. New Applications should use AerialWithLabelsOnDemand instead. To read up more please have a look at the provided link. https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata?redirectedfrom=MSDN.