### PR TITLE
Replace rawgit URLs with GitHub URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,5 +58,5 @@ Suggests:
     testthat (>= 3.0.0)
 URL: https://github.com/trafficonese/leaflet.extras, https://trafficonese.github.io/leaflet.extras/
 BugReports: https://github.com/trafficonese/leaflet.extras/issues
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/testthat/edition: 3

--- a/R/measure-path.R
+++ b/R/measure-path.R
@@ -11,7 +11,7 @@ measurePathDependencies <- function() {
 #' @examples
 #' \donttest{
 #' geoJson <- readr::read_file(
-#'   "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+#'   "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 #' )
 #'
 #' leaflet() %>%

--- a/R/omnivore.R
+++ b/R/omnivore.R
@@ -127,7 +127,7 @@ invokeJSAddMethod <- function(
 #' ## addGeoJSONv2
 #' \donttest{
 #' geoJson <- readr::read_file(
-#'   "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+#'   "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 #' )
 #'
 #' leaflet() %>%
@@ -238,7 +238,7 @@ legendOptions <- function(
 #' ## addGeoJSONChoropleth
 #' \donttest{
 #' geoJson <- readr::read_file(
-#'   "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+#'   "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 #' )
 #'
 #' leaflet() %>%

--- a/R/webGLHeatmap.R
+++ b/R/webGLHeatmap.R
@@ -104,7 +104,7 @@ addWebGLHeatmap <- function(
 #' ## addWebGLGeoJSONHeatmap
 #' \donttest{
 #' geoJson <- readr::read_file(
-#'   "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+#'   "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 #' )
 #'
 #' leaflet() %>%

--- a/inst/examples/TopoJSON.R
+++ b/inst/examples/TopoJSON.R
@@ -27,7 +27,7 @@ leaflet() %>%
 
 #' We plot some crime stats by district. Notice the convenient "propsToHTMLTable" function for pretty popups.
 #'
-fName <- "https://rawgit.com/TrantorM/leaflet-choropleth/gh-pages/examples/basic_topo/crimes_by_district.topojson"
+fName <- "https://github.com/TrantorM/leaflet-choropleth/blob/gh-pages/examples/basic_topo/crimes_by_district.topojson"
 topoJson <- readr::read_file(fName)
 
 leaflet() %>%

--- a/inst/examples/draw.R
+++ b/inst/examples/draw.R
@@ -68,7 +68,7 @@ leaflet() %>% addTiles() %>%
 #' ### Add GeoJSON and then edit it
 #' The layerId of the GeoJSON has to match the targetLayerId of `addDrawToolbar`. Also notice that we have to simplify the geometry quite a bit using `rmapshaper::ms_simplify`, otherwise the edit feature is very slow and will even hang the browser.
 
-fName <- "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+fName <- "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 
 geoJson <- readr::read_file(fName)
 geoJson2 <- rmapshaper::ms_simplify(geoJson, keep = 0.01)

--- a/inst/examples/geojsonv2.R
+++ b/inst/examples/geojsonv2.R
@@ -21,7 +21,7 @@ leaf <- leaflet() %>%
 #'
 
 # Read as a R list
-fName <- "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+fName <- "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 geoJson <- jsonlite::fromJSON(readr::read_file(fName))
 
 factpal <- colorFactor(topo.colors(nrow(geoJson$features$properties)),
@@ -155,7 +155,7 @@ leaf.world %>%
 #'
 #' Here again we don't do any pre-processing in R, everything is done on the browser side.
 
-fName <- "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+fName <- "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 
 geoJson <- readr::read_file(fName)
 
@@ -200,7 +200,7 @@ leaf %>% setView(-77.0369, 38.9072, 11) %>%
 #'
 #' ### Example 1
 #' Here we plot GeoJSON with Point data using customized markers
-jsURL <- "https://rawgit.com/Norkart/Leaflet-MiniMap/master/example/local_pubs_restaurant_norway.js"
+jsURL <- "https://github.com/Norkart/Leaflet-MiniMap/blob/master/example/local_pubs_restaurant_norway.js"
 v8 <- V8::v8()
 v8$source(jsURL)
 geoJson <- v8$get("pubsGeoJSON")
@@ -224,7 +224,7 @@ leaf %>%
 #' Here we plot arts/cultural places and historic places in Washington DC. Notice that we are not loading the GeoJSONs in R, but directly downloading them and parsing them int the browser. We are also specifying popups content to be generated from the feature properties. We are also using marker clustering to cluster our points.
 
 artsAndCultures <- "https://rawgit.com/benbalter/dc-maps/master/maps/arts-and-culture-organizations-as-501-c-3.geojson"
-historicLandmarks <- "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+historicLandmarks <- "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 
 artsAndCulture <- makeAwesomeIcon(icon = "paintbrush", library = "ion", markerColor = "red", iconColor = "black")
 historicLandmark <- makeAwesomeIcon(icon = "flag", library = "ion", markerColor = "green", iconColor = "black")
@@ -256,7 +256,7 @@ leaf %>% setView(-77.0369, 38.9072, 12) %>%
 #' ### Example 3
 #'
 #' This time in addition to the points we also plot the heatmap
-fName <- "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+fName <- "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 
 geoJson <- readr::read_file(fName)
 

--- a/inst/examples/heatmaps.R
+++ b/inst/examples/heatmaps.R
@@ -13,7 +13,7 @@ leaflet(quakes) %>% addProviderTiles(providers$CartoDB.DarkMatter) %>%
 #' Roughly 1500 points dataset
 #'
 library(sp)
-jsURL <- "https://rawgit.com/Norkart/Leaflet-MiniMap/master/example/local_pubs_restaurant_norway.js"
+jsURL <- "https://github.com/Norkart/Leaflet-MiniMap/blob/master/example/local_pubs_restaurant_norway.js"
 v8 <- V8::v8()
 v8$source(jsURL)
 geoJson <- geojsonio::as.json(v8$get("pubsGeoJSON"))

--- a/inst/examples/measurePath.R
+++ b/inst/examples/measurePath.R
@@ -3,7 +3,7 @@ library(leaflet.extras)
 
 #' ### Add shapes with measurements enabled
 
-fName <- "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+fName <- "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 
 geoJson <- readr::read_file(fName)
 

--- a/inst/examples/search.R
+++ b/inst/examples/search.R
@@ -67,7 +67,7 @@ leaflet(nc) %>%
 
 #' ### Search GeoJSON Markers
 # GeoJSON w/ Markers ----
-jsURL <- "https://rawgit.com/Norkart/Leaflet-MiniMap/master/example/local_pubs_restaurant_norway.js"
+jsURL <- "https://github.com/Norkart/Leaflet-MiniMap/blob/master/example/local_pubs_restaurant_norway.js"
 v8 <- V8::v8()
 v8$source(jsURL)
 geoJson <- v8$get("pubsGeoJSON")

--- a/inst/examples/webglHeatmaps.R
+++ b/inst/examples/webglHeatmaps.R
@@ -18,7 +18,7 @@ leaflet(quakes) %>% addProviderTiles(providers$CartoDB.DarkMatter) %>%
 #' Roughly 1500 points dataset
 #'
 library(sp)
-jsURL <- "https://rawgit.com/Norkart/Leaflet-MiniMap/master/example/local_pubs_restaurant_norway.js"
+jsURL <- "https://github.com/Norkart/Leaflet-MiniMap/blob/master/example/local_pubs_restaurant_norway.js"
 v8 <- V8::v8()
 v8$source(jsURL)
 geoJson <- geojsonio::as.json(v8$get("pubsGeoJSON"))

--- a/man/addBounceMarkers.Rd
+++ b/man/addBounceMarkers.Rd
@@ -22,7 +22,7 @@ addBounceMarkers(
 )
 }
 \arguments{
-\item{map}{a map widget object created from \code{\link[leaflet]{leaflet}()}}
+\item{map}{a map widget object created from \code{\link[leaflet:leaflet]{leaflet()}}}
 
 \item{lng}{a numeric vector of longitudes, or a one-sided formula of the form
 \code{~x} where \code{x} is a variable in \code{data}; by default (if not
@@ -37,14 +37,14 @@ the latitude column from \code{data})}
 \item{layerId}{the layer id}
 
 \item{group}{the name of the group the newly created layers should belong to
-(for \code{\link[leaflet]{clearGroup}} and \code{\link[leaflet]{addLayersControl}} purposes).
+(for \code{\link[leaflet:clearGroup]{clearGroup()}} and \code{\link[leaflet:addLayersControl]{addLayersControl()}} purposes).
 Human-friendly group names are permitted--they need not be short,
 identifier-style names. Any number of layers and even different types of
-layers (e.g. markers and polygons) can share the same group name.}
+layers (e.g., markers and polygons) can share the same group name.}
 
 \item{icon}{the icon(s) for markers; an icon is represented by an R list of
 the form \code{list(iconUrl = "?", iconSize = c(x, y))}, and you can use
-\code{\link[leaflet]{icons}()} to create multiple icons; note when you use an R list
+\code{\link[leaflet:icons]{icons()}} to create multiple icons; note when you use an R list
 that contains images as local files, these local image files will be base64
 encoded into the HTML page so the icon images will still be available even
 when you publish the map elsewhere}
@@ -54,14 +54,14 @@ when you publish the map elsewhere}
 \item{height}{integer scalar: Height at which the marker is dropped.}
 
 \item{popup}{a character vector of the HTML content for the popups (you are
-recommended to escape the text using \code{\link[htmltools]{htmlEscape}()}
+recommended to escape the text using \code{\link[htmltools:htmlEscape]{htmltools::htmlEscape()}}
 for security reasons)}
 
-\item{popupOptions}{A Vector of \code{\link[leaflet]{popupOptions}} to provide popups}
+\item{popupOptions}{A Vector of \code{\link[leaflet:popupOptions]{popupOptions()}} to provide popups}
 
 \item{label}{a character vector of the HTML content for the labels}
 
-\item{labelOptions}{A Vector of \code{\link[leaflet]{labelOptions}} to provide label
+\item{labelOptions}{A Vector of \code{\link[leaflet:labelOptions]{labelOptions()}} to provide label
 options for each label. Default \code{NULL}}
 
 \item{options}{a list of extra options for tile layers, popups, paths

--- a/man/addGroupedLayersControl.Rd
+++ b/man/addGroupedLayersControl.Rd
@@ -22,8 +22,8 @@ most commonly used for mostly-opaque tile layers.}
 \item{overlayGroups}{A list of named vectors where each element is the name
 of a group.}
 
-\item{position}{position of control: "topleft", "topright", "bottomleft", or
-"bottomright"}
+\item{position}{position of control: \code{"topleft"}, \code{"topright"},
+\code{"bottomleft"}, or \code{"bottomright"}.}
 
 \item{options}{a list of additional options, intended to be provided by a
 call to \code{\link{groupedLayersControlOptions}}}

--- a/man/geodesics.Rd
+++ b/man/geodesics.Rd
@@ -70,17 +70,17 @@ addGreatCircles(
 )
 }
 \arguments{
-\item{map}{a map widget object created from \code{\link[leaflet]{leaflet}()}}
+\item{map}{a map widget object created from \code{\link[leaflet:leaflet]{leaflet()}}}
 
 \item{lat, lng}{lat/lng to add to the Geodesic}
 
 \item{layerId}{the layer id}
 
 \item{group}{the name of the group the newly created layers should belong to
-(for \code{\link[leaflet]{clearGroup}} and \code{\link[leaflet]{addLayersControl}} purposes).
+(for \code{\link[leaflet:clearGroup]{clearGroup()}} and \code{\link[leaflet:addLayersControl]{addLayersControl()}} purposes).
 Human-friendly group names are permitted--they need not be short,
 identifier-style names. Any number of layers and even different types of
-layers (e.g. markers and polygons) can share the same group name.}
+layers (e.g., markers and polygons) can share the same group name.}
 
 \item{steps}{Defines how many intermediate points are generated along the path.
 More steps mean a smoother path.}
@@ -88,7 +88,7 @@ More steps mean a smoother path.}
 \item{wrap}{Wrap line at map border (date line). Set to "false" if you want
 lines to cross the dateline (experimental, see noWrap-example on how to use)}
 
-\item{stroke}{whether to draw stroke along the path (e.g. the borders of
+\item{stroke}{whether to draw stroke along the path (e.g., the borders of
 polygons or circles)}
 
 \item{color}{stroke color}
@@ -97,9 +97,7 @@ polygons or circles)}
 
 \item{opacity}{stroke opacity (or layer opacity for tile layers)}
 
-\item{dashArray}{a string that defines the stroke
-\href{https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray}{dash
-pattern}}
+\item{dashArray}{a string that defines the stroke \href{https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray}{dash pattern}}
 
 \item{smoothFactor}{how much to simplify the polyline on each zoom level
 (more means better performance and less accurate representation)}
@@ -107,14 +105,14 @@ pattern}}
 \item{noClip}{whether to disable polyline clipping}
 
 \item{popup}{a character vector of the HTML content for the popups (you are
-recommended to escape the text using \code{\link[htmltools]{htmlEscape}()}
+recommended to escape the text using \code{\link[htmltools:htmlEscape]{htmltools::htmlEscape()}}
 for security reasons)}
 
-\item{popupOptions}{A Vector of \code{\link[leaflet]{popupOptions}} to provide popups}
+\item{popupOptions}{A Vector of \code{\link[leaflet:popupOptions]{popupOptions()}} to provide popups}
 
 \item{label}{a character vector of the HTML content for the labels}
 
-\item{labelOptions}{A Vector of \code{\link[leaflet]{labelOptions}} to provide label
+\item{labelOptions}{A Vector of \code{\link[leaflet:labelOptions]{labelOptions()}} to provide label
 options for each label. Default \code{NULL}}
 
 \item{options}{a list of extra options for tile layers, popups, paths
@@ -124,7 +122,7 @@ options for each label. Default \code{NULL}}
 
 \item{icon}{the icon(s) for markers; an icon is represented by an R list of
 the form \code{list(iconUrl = "?", iconSize = c(x, y))}, and you can use
-\code{\link[leaflet]{icons}()} to create multiple icons; note when you use an R list
+\code{\link[leaflet:icons]{icons()}} to create multiple icons; note when you use an R list
 that contains images as local files, these local image files will be base64
 encoded into the HTML page so the icon images will still be available even
 when you publish the map elsewhere}
@@ -145,7 +143,7 @@ initially, but can be overridden}
 
 \item{radius}{in meters}
 
-\item{fill}{whether to fill the path with color (e.g. filling on polygons or
+\item{fill}{whether to fill the path with color (e.g., filling on polygons or
 circles)}
 }
 \description{

--- a/man/heatmap.Rd
+++ b/man/heatmap.Rd
@@ -88,7 +88,7 @@ removeHeatmap(map, layerId)
 clearHeatmap(map)
 }
 \arguments{
-\item{map}{a map widget object created from \code{\link[leaflet]{leaflet}()}}
+\item{map}{a map widget object created from \code{\link[leaflet:leaflet]{leaflet()}}}
 
 \item{lng}{a numeric vector of longitudes, or a one-sided formula of the form
 \code{~x} where \code{x} is a variable in \code{data}; by default (if not
@@ -105,10 +105,10 @@ the latitude column from \code{data})}
 \item{layerId}{the layer id}
 
 \item{group}{the name of the group the newly created layers should belong to
-(for \code{\link[leaflet]{clearGroup}} and \code{\link[leaflet]{addLayersControl}} purposes).
+(for \code{\link[leaflet:clearGroup]{clearGroup()}} and \code{\link[leaflet:addLayersControl]{addLayersControl()}} purposes).
 Human-friendly group names are permitted--they need not be short,
 identifier-style names. Any number of layers and even different types of
-layers (e.g. markers and polygons) can share the same group name.}
+layers (e.g., markers and polygons) can share the same group name.}
 
 \item{minOpacity}{minimum opacity at which the heat will start}
 

--- a/man/measure-path.Rd
+++ b/man/measure-path.Rd
@@ -47,7 +47,7 @@ Adds a toolbar to enable/disable measuring path distances/areas
 \examples{
 \donttest{
 geoJson <- readr::read_file(
-  "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+  "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 )
 
 leaflet() \%>\%

--- a/man/omnivore.Rd
+++ b/man/omnivore.Rd
@@ -200,17 +200,17 @@ addGPX(
 )
 }
 \arguments{
-\item{map}{a map widget object created from \code{\link[leaflet]{leaflet}()}}
+\item{map}{a map widget object created from \code{\link[leaflet:leaflet]{leaflet()}}}
 
 \item{geojson}{a GeoJSON/TopoJSON URL or file contents in a character vector.}
 
 \item{layerId}{the layer id}
 
 \item{group}{the name of the group the newly created layers should belong to
-(for \code{\link[leaflet]{clearGroup}} and \code{\link[leaflet]{addLayersControl}} purposes).
+(for \code{\link[leaflet:clearGroup]{clearGroup()}} and \code{\link[leaflet:addLayersControl]{addLayersControl()}} purposes).
 Human-friendly group names are permitted--they need not be short,
 identifier-style names. Any number of layers and even different types of
-layers (e.g. markers and polygons) can share the same group name.}
+layers (e.g., markers and polygons) can share the same group name.}
 
 \item{markerType}{The type of marker. Either \code{marker} or \code{circleMarker}}
 
@@ -226,7 +226,7 @@ In either case the result must be one of the indexes of markerIcons.}
 
 \item{clusterOptions}{if not \code{NULL}, markers will be clustered using
 \href{https://github.com/Leaflet/Leaflet.markercluster}{Leaflet.markercluster};
- you can use \code{\link[leaflet]{markerClusterOptions}()} to specify marker cluster
+you can use \code{\link[leaflet:markerClusterOptions]{markerClusterOptions()}} to specify marker cluster
 options}
 
 \item{clusterId}{the id for the marker cluster layer}
@@ -234,15 +234,15 @@ options}
 \item{labelProperty}{The property to use for the label.
 You can also pass in a JS function that takes in a feature and returns a text/HTML content.}
 
-\item{labelOptions}{A Vector of \code{\link[leaflet]{labelOptions}} to provide label
+\item{labelOptions}{A Vector of \code{\link[leaflet:labelOptions]{labelOptions()}} to provide label
 options for each label. Default \code{NULL}}
 
 \item{popupProperty}{The property to use for popup content
 You can also pass in a JS function that takes in a feature and returns a text/HTML content.}
 
-\item{popupOptions}{A Vector of \code{\link[leaflet]{popupOptions}} to provide popups}
+\item{popupOptions}{A Vector of \code{\link[leaflet:popupOptions]{popupOptions()}} to provide popups}
 
-\item{stroke}{whether to draw stroke along the path (e.g. the borders of
+\item{stroke}{whether to draw stroke along the path (e.g., the borders of
 polygons or circles)}
 
 \item{color}{stroke color}
@@ -251,16 +251,14 @@ polygons or circles)}
 
 \item{opacity}{stroke opacity (or layer opacity for tile layers)}
 
-\item{fill}{whether to fill the path with color (e.g. filling on polygons or
+\item{fill}{whether to fill the path with color (e.g., filling on polygons or
 circles)}
 
 \item{fillColor}{fill color}
 
 \item{fillOpacity}{fill opacity}
 
-\item{dashArray}{a string that defines the stroke
-\href{https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray}{dash
-pattern}}
+\item{dashArray}{a string that defines the stroke \href{https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray}{dash pattern}}
 
 \item{smoothFactor}{how much to simplify the polyline on each zoom level
 (more means better performance and less accurate representation)}
@@ -322,7 +320,7 @@ with options to map feature properties to labels, popups, colors, markers etc.
 ## addGeoJSONv2
 \donttest{
 geoJson <- readr::read_file(
-  "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+  "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 )
 
 leaflet() \%>\%
@@ -349,7 +347,7 @@ leaflet() \%>\%
 ## addGeoJSONChoropleth
 \donttest{
 geoJson <- readr::read_file(
-  "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+  "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 )
 
 leaflet() \%>\%

--- a/man/pulseMarkers.Rd
+++ b/man/pulseMarkers.Rd
@@ -62,7 +62,7 @@ addPulseMarkers(
 
 \item{heartbeat}{Interval between each pulse in seconds.}
 
-\item{map}{a map widget object created from \code{\link[leaflet]{leaflet}()}}
+\item{map}{a map widget object created from \code{\link[leaflet:leaflet]{leaflet()}}}
 
 \item{lng}{a numeric vector of longitudes, or a one-sided formula of the form
 \code{~x} where \code{x} is a variable in \code{data}; by default (if not
@@ -77,27 +77,27 @@ the latitude column from \code{data})}
 \item{layerId}{the layer id}
 
 \item{group}{the name of the group the newly created layers should belong to
-(for \code{\link[leaflet]{clearGroup}} and \code{\link[leaflet]{addLayersControl}} purposes).
+(for \code{\link[leaflet:clearGroup]{clearGroup()}} and \code{\link[leaflet:addLayersControl]{addLayersControl()}} purposes).
 Human-friendly group names are permitted--they need not be short,
 identifier-style names. Any number of layers and even different types of
-layers (e.g. markers and polygons) can share the same group name.}
+layers (e.g., markers and polygons) can share the same group name.}
 
 \item{icon}{the icon(s) for markers; an icon is represented by an R list of
 the form \code{list(iconUrl = "?", iconSize = c(x, y))}, and you can use
-\code{\link[leaflet]{icons}()} to create multiple icons; note when you use an R list
+\code{\link[leaflet:icons]{icons()}} to create multiple icons; note when you use an R list
 that contains images as local files, these local image files will be base64
 encoded into the HTML page so the icon images will still be available even
 when you publish the map elsewhere}
 
 \item{popup}{a character vector of the HTML content for the popups (you are
-recommended to escape the text using \code{\link[htmltools]{htmlEscape}()}
+recommended to escape the text using \code{\link[htmltools:htmlEscape]{htmltools::htmlEscape()}}
 for security reasons)}
 
-\item{popupOptions}{A Vector of \code{\link[leaflet]{popupOptions}} to provide popups}
+\item{popupOptions}{A Vector of \code{\link[leaflet:popupOptions]{popupOptions()}} to provide popups}
 
 \item{label}{a character vector of the HTML content for the labels}
 
-\item{labelOptions}{A Vector of \code{\link[leaflet]{labelOptions}} to provide label
+\item{labelOptions}{A Vector of \code{\link[leaflet:labelOptions]{labelOptions()}} to provide label
 options for each label. Default \code{NULL}}
 
 \item{options}{a list of extra options for tile layers, popups, paths
@@ -105,7 +105,7 @@ options for each label. Default \code{NULL}}
 
 \item{clusterOptions}{if not \code{NULL}, markers will be clustered using
 \href{https://github.com/Leaflet/Leaflet.markercluster}{Leaflet.markercluster};
- you can use \code{\link[leaflet]{markerClusterOptions}()} to specify marker cluster
+you can use \code{\link[leaflet:markerClusterOptions]{markerClusterOptions()}} to specify marker cluster
 options}
 
 \item{clusterId}{the id for the marker cluster layer}

--- a/man/weatherMarkers.Rd
+++ b/man/weatherMarkers.Rd
@@ -58,7 +58,7 @@ addWeatherMarkers(
 
 \item{extraClasses}{Character vector of extra classes.}
 
-\item{map}{a map widget object created from \code{\link[leaflet]{leaflet}()}}
+\item{map}{a map widget object created from \code{\link[leaflet:leaflet]{leaflet()}}}
 
 \item{lng}{a numeric vector of longitudes, or a one-sided formula of the form
 \code{~x} where \code{x} is a variable in \code{data}; by default (if not
@@ -73,20 +73,20 @@ the latitude column from \code{data})}
 \item{layerId}{the layer id}
 
 \item{group}{the name of the group the newly created layers should belong to
-(for \code{\link[leaflet]{clearGroup}} and \code{\link[leaflet]{addLayersControl}} purposes).
+(for \code{\link[leaflet:clearGroup]{clearGroup()}} and \code{\link[leaflet:addLayersControl]{addLayersControl()}} purposes).
 Human-friendly group names are permitted--they need not be short,
 identifier-style names. Any number of layers and even different types of
-layers (e.g. markers and polygons) can share the same group name.}
+layers (e.g., markers and polygons) can share the same group name.}
 
 \item{popup}{a character vector of the HTML content for the popups (you are
-recommended to escape the text using \code{\link[htmltools]{htmlEscape}()}
+recommended to escape the text using \code{\link[htmltools:htmlEscape]{htmltools::htmlEscape()}}
 for security reasons)}
 
-\item{popupOptions}{A Vector of \code{\link[leaflet]{popupOptions}} to provide popups}
+\item{popupOptions}{A Vector of \code{\link[leaflet:popupOptions]{popupOptions()}} to provide popups}
 
 \item{label}{a character vector of the HTML content for the labels}
 
-\item{labelOptions}{A Vector of \code{\link[leaflet]{labelOptions}} to provide label
+\item{labelOptions}{A Vector of \code{\link[leaflet:labelOptions]{labelOptions()}} to provide label
 options for each label. Default \code{NULL}}
 
 \item{options}{a list of extra options for tile layers, popups, paths
@@ -94,7 +94,7 @@ options for each label. Default \code{NULL}}
 
 \item{clusterOptions}{if not \code{NULL}, markers will be clustered using
 \href{https://github.com/Leaflet/Leaflet.markercluster}{Leaflet.markercluster};
- you can use \code{\link[leaflet]{markerClusterOptions}()} to specify marker cluster
+you can use \code{\link[leaflet:markerClusterOptions]{markerClusterOptions()}} to specify marker cluster
 options}
 
 \item{clusterId}{the id for the marker cluster layer}

--- a/man/webglheatmap.Rd
+++ b/man/webglheatmap.Rd
@@ -83,7 +83,7 @@ removeWebGLHeatmap(map, layerId)
 clearWebGLHeatmap(map)
 }
 \arguments{
-\item{map}{a map widget object created from \code{\link[leaflet]{leaflet}()}}
+\item{map}{a map widget object created from \code{\link[leaflet:leaflet]{leaflet()}}}
 
 \item{lng}{a numeric vector of longitudes, or a one-sided formula of the form
 \code{~x} where \code{x} is a variable in \code{data}; by default (if not
@@ -100,10 +100,10 @@ the latitude column from \code{data})}
 \item{layerId}{the layer id}
 
 \item{group}{the name of the group the newly created layers should belong to
-(for \code{\link[leaflet]{clearGroup}} and \code{\link[leaflet]{addLayersControl}} purposes).
+(for \code{\link[leaflet:clearGroup]{clearGroup()}} and \code{\link[leaflet:addLayersControl]{addLayersControl()}} purposes).
 Human-friendly group names are permitted--they need not be short,
 identifier-style names. Any number of layers and even different types of
-layers (e.g. markers and polygons) can share the same group name.}
+layers (e.g., markers and polygons) can share the same group name.}
 
 \item{size}{in meters or pixels}
 
@@ -160,7 +160,7 @@ leaflet(quakes) \%>\%
 ## addWebGLGeoJSONHeatmap
 \donttest{
 geoJson <- readr::read_file(
-  "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+  "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 )
 
 leaflet() \%>\%

--- a/man/wms-legend.Rd
+++ b/man/wms-legend.Rd
@@ -16,7 +16,7 @@ addWMSLegend(
 )
 }
 \arguments{
-\item{map}{a map widget object created from \code{\link[leaflet]{leaflet}()}}
+\item{map}{a map widget object created from \code{\link[leaflet:leaflet]{leaflet()}}}
 
 \item{uri}{The legend URI}
 

--- a/tests/testthat/test-geojson.R
+++ b/tests/testthat/test-geojson.R
@@ -16,7 +16,7 @@
 #'     addProviderTiles(providers$CartoDB.Positron)
 #'
 #'   # Read as a R list
-#'   fName <- "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+#'   fName <- "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 #'   geoJson <- jsonlite::fromJSON(readr::read_file(fName))
 #'
 #'   factpal <- colorFactor(
@@ -175,7 +175,7 @@
 #'   #'
 #'   #' Here again we don't do any pre-processing in R, everything is done on the browser side.
 #'
-#'   fName <- "https://rawgit.com/benbalter/dc-maps/master/maps/ward-2012.geojson"
+#'   fName <- "https://github.com/benbalter/dc-maps/blob/master/maps/ward-2012.geojson"
 #'
 #'   geoJson <- readr::read_file(fName)
 #'
@@ -232,7 +232,7 @@
 #'   #'
 #'   #' ### Example 1
 #'   #' Here we plot GeoJSON with Point data using customized markers
-#'   jsURL <- "https://rawgit.com/Norkart/Leaflet-MiniMap/master/example/local_pubs_restaurant_norway.js"
+#'   jsURL <- "https://github.com/Norkart/Leaflet-MiniMap/blob/master/example/local_pubs_restaurant_norway.js"
 #'   v8 <- V8::v8()
 #'   v8$source(jsURL)
 #'   geoJson <- v8$get("pubsGeoJSON")
@@ -267,7 +267,7 @@
 #'   #' Here we plot arts/cultural places and historic places in Washington DC. Notice that we are not loading the GeoJSONs in R, but directly downloading them and parsing them int the browser. We are also specifying popups content to be generated from the feature properties. We are also using marker clustering to cluster our points.
 #'
 #'   artsAndCultures <- "https://rawgit.com/benbalter/dc-maps/master/maps/arts-and-culture-organizations-as-501-c-3.geojson"
-#'   historicLandmarks <- "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+#'   historicLandmarks <- "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 #'
 #'   artsAndCulture <- makeAwesomeIcon(icon = "paintbrush", library = "ion", markerColor = "red", iconColor = "black")
 #'   historicLandmark <- makeAwesomeIcon(icon = "flag", library = "ion", markerColor = "green", iconColor = "black")
@@ -315,7 +315,7 @@
 #'   #' ### Example 3
 #'   #'
 #'   #' This time in addition to the points we also plot the heatmap
-#'   fName <- "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+#'   fName <- "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 #'
 #'   geoJson <- readr::read_file(fName)
 #'

--- a/tests/testthat/test-geojson_mini.R
+++ b/tests/testthat/test-geojson_mini.R
@@ -1,7 +1,7 @@
 ## DATA ###################
-fName <- "https://rawgit.com/TrantorM/leaflet-choropleth/gh-pages/examples/basic_topo/crimes_by_district.topojson"
+fName <- "https://github.com/TrantorM/leaflet-choropleth/blob/gh-pages/examples/basic_topo/crimes_by_district.topojson"
 topoJson <- readr::read_file(fName)
-geosonpointurl <- "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+geosonpointurl <- "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 geoJson <- readr::read_file(geosonpointurl)
 
 historicLandmark <- makeAwesomeIcon(icon = "flag", library = "ion", markerColor = "green", iconColor = "black")

--- a/tests/testthat/test-heatmaps.R
+++ b/tests/testthat/test-heatmaps.R
@@ -1,6 +1,6 @@
 ## Data ##############
 geoJson <- readr::read_file(
-  "https://rawgit.com/benbalter/dc-maps/master/maps/historic-landmarks-points.geojson"
+  "https://github.com/benbalter/dc-maps/blob/master/maps/historic-landmarks-points.geojson"
 )
 kml <- readr::read_file(
   system.file("examples/data/kml/crimes.kml.zip", package = "leaflet.extras")


### PR DESCRIPTION
Fix broken URLs causing CRAN removal. rawgit is no longer online, so this PR updates all rawgit URLs to their GitHub equivalents, restoring passing tests and working examples.

#250